### PR TITLE
simplify play dockerfile

### DIFF
--- a/play/Dockerfile.play
+++ b/play/Dockerfile.play
@@ -5,7 +5,7 @@ MAINTAINER tech@flow.io
 WORKDIR /root
 
 # install stuff
-RUN apk add --no-cache --virtual=build-dependencies curl bash
+RUN apk add --no-cache bash
 
 COPY environment-provider.jar .
 COPY environment-provider-version.txt .


### PR DESCRIPTION
- `--virtual=build-dependencies` just gives a name to all the package you install, so that you can easily `apk del build-dependencies`. We never uninstall so this is not necessary
- I'm pretty sure `curl` is not needed at runtime