### PR TITLE
Fix copying .sbt and .ivy2 caches

### DIFF
--- a/play/Dockerfile.play_builder
+++ b/play/Dockerfile.play_builder
@@ -16,5 +16,5 @@ RUN apk add --no-cache --update bash && \
     mkdir -p .sbt/ && \
     mkdir -p .ivy2/
 
-COPY .sbt/ .sbt/.
-COPY .ivy2 .ivy2/.
+COPY .sbt .
+COPY .ivy2 .


### PR DESCRIPTION
So far builds issued by delta downloads all sbt and scala dependency jars, as you can see on example here: https://travis-ci.com/flowcommerce/marketing/builds/77573018

In Dockerfile there is attempt to copy existing caches, but I think copy statement is created in a way that the caches are copied to `.sbt/.sbt` and `.ivy2/.ivy2`, making them ineffectful.

This PR fixes it so that delta deployments should use copied caches and not download the whole world on every build.