### PR TITLE
Add curl to node image

### DIFF
--- a/node/Dockerfile.node
+++ b/node/Dockerfile.node
@@ -30,7 +30,7 @@ COPY environment-provider.jar .
 COPY environment-provider-version.txt .
 
 RUN npm install -g forever && \
-    apk add --no-cache --update ca-certificates && \
+    apk add --no-cache --update ca-certificates curl && \
     rm /var/cache/apk/* && \
     mkdir -p /opt/node/log
 


### PR DESCRIPTION
Current Docker healthchecks are failing on Console due to `curl` being missing from the docker image.