### PR TITLE
Add gcc dep to node_builder docker image

### DIFF
--- a/node/Dockerfile.node_builder
+++ b/node/Dockerfile.node_builder
@@ -35,7 +35,7 @@ COPY environment-provider.jar .
 COPY environment-provider-version.txt .
 
 RUN npm install -g forever && \
-    apk add --no-cache --update python py-pip ca-certificates musl-dev git go dep make && \
+    apk add --no-cache --update python py-pip ca-certificates musl-dev git go dep make build-base && \
     pip install --upgrade awscli && \
     apk -v --purge del py-pip && \
     mkdir -p /root/go && \


### PR DESCRIPTION
Previously published version `0.2.0` of `flowdocker/node_builder` was an upgrade to newest version of alpine linux and Node v12. It seems to be missing the `gcc` compiler required to build native extension to node modules (when applicable).

New version will be `0.2.1`