### PR TITLE
node_builder: build with NODE_ENV unset

### DIFF
--- a/node/Dockerfile.node_builder
+++ b/node/Dockerfile.node_builder
@@ -5,7 +5,6 @@ LABEL maintainer="tech@flow.io"
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
-ENV NODE_ENV production
 ENV GOPATH /root/go
 ENV GOBIN $GOPATH/bin
 ENV PATH $PATH:$GOBIN


### PR DESCRIPTION
It seems wrong to use NODE_ENV in production for the builder image, if you want to build stuff using tools like typescript which go in devDependencies.