### PR TITLE
Upgrade node docker images to node v16

### DIFF
--- a/node/Dockerfile.node
+++ b/node/Dockerfile.node
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:16-alpine
 
 LABEL maintainer="tech@flow.io"
 

--- a/node/Dockerfile.node_builder
+++ b/node/Dockerfile.node_builder
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:16-alpine
 
 LABEL maintainer="tech@flow.io"
 
@@ -15,7 +15,7 @@ ARG GITHUB_TOKEN
 WORKDIR /root
 
 RUN npm install -g forever && \
-    apk add --no-cache --update python py-pip ca-certificates musl-dev git go make build-base && \
+    apk add --no-cache --update python3 py-pip ca-certificates musl-dev git go make build-base && \
     pip install --upgrade awscli && \
     apk -v --purge del py-pip
 

--- a/node/build-node
+++ b/node/build-node
@@ -39,11 +39,13 @@ begin
     run("curl https://cdn.flow.io/util/environment-provider/environment-provider_2.12-#{env_provider_version}-one-jar.jar > ./environment-provider.jar")
     run("aws s3 cp s3://io.flow.infra/npm/flowtech.npmrc ./.npmrc")
     run("docker build --no-cache -t %s ." % node_image_tag, true)
+    run("docker build --no-cache -t %s ." % node_image_tag, true)
   end
-
-  run("docker push %s" % node_image_tag)
-  puts ""
-  puts "Completed build and push of #{node_image_tag}"
+  if confirm("Enter 'Y' to push this image (%s) to Docker hub" % node_image_tag)
+    run("docker push %s" % node_image_tag)
+    puts ""
+    puts "Completed push of #{node_image_tag}"
+  end
 rescue StandardError => e
   puts e.message
 ensure

--- a/node/build-node
+++ b/node/build-node
@@ -39,7 +39,6 @@ begin
     run("curl https://cdn.flow.io/util/environment-provider/environment-provider_2.12-#{env_provider_version}-one-jar.jar > ./environment-provider.jar")
     run("aws s3 cp s3://io.flow.infra/npm/flowtech.npmrc ./.npmrc")
     run("docker build --no-cache -t %s ." % node_image_tag, true)
-    run("docker build --no-cache -t %s ." % node_image_tag, true)
   end
   if confirm("Enter 'Y' to push this image (%s) to Docker hub" % node_image_tag)
     run("docker push %s" % node_image_tag)

--- a/node/build-node_builder
+++ b/node/build-node_builder
@@ -8,7 +8,6 @@
 
 require "./helpers.rb"
 
-
 def usage()
   puts ""
   puts "Usage:"
@@ -60,9 +59,14 @@ begin
     run("docker build --no-cache --build-arg GITHUB_TOKEN=#{ENV[github_token_var_name]} -t %s ." % node_image_tag)
   end
 
-  run("docker push %s" % node_image_tag)
   puts ""
-  puts "Completed build and push of #{node_image_tag}"
+  puts "Completed build of #{node_image_tag}"
+
+  if confirm("Enter 'Y' to push this image (%s) to Docker hub" % node_image_tag)
+    run("docker push %s" % node_image_tag)
+    puts ""
+    puts "Completed push of #{node_image_tag}"
+  end
 rescue StandardError => e
   puts e.message
 ensure

--- a/node/helpers.rb
+++ b/node/helpers.rb
@@ -25,3 +25,9 @@ def get_env_providor_location()
   puts "Found environment-provider repo at: [#{found_path}]"
   found_path
 end
+
+def confirm(message)
+  puts message
+  input = gets.chomp
+  input.casecmp('y') == 0
+end


### PR DESCRIPTION
I have not been able to test building these as it's problematic on M1 `arm64` architecture. I tried but for now I think just building on an Intel Mac will be easier.

New version of both docker images proposed to be: `0.4.0`