### PR TITLE
Remove deprecated engine feature

### DIFF
--- a/play/Dockerfile.play-13
+++ b/play/Dockerfile.play-13
@@ -1,6 +1,6 @@
 FROM openjdk:13-jdk-buster
 
-MAINTAINER tech@flow.io
+LABEL maintainer="tech@flow.io"
 
 RUN sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=10/ $JAVA_HOME/conf/security/java.security
 

--- a/play/Dockerfile.play_builder-13
+++ b/play/Dockerfile.play_builder-13
@@ -1,6 +1,6 @@
 FROM openjdk:13-jdk-alpine
 
-MAINTAINER tech@flow.io
+LABEL maintainer="tech@flow.io"
 
 ENV SBT_VERSION 1.3.10
 

--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -22,7 +22,7 @@ FROM ubuntu:18.04
 #  psql -U api -h 192.168.99.100 -p 5100 splashpagedb
 #
 
-MAINTAINER tech@flow.io
+LABEL maintainer="tech@flow.io"
 
 RUN apt-get update
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main' >> /etc/apt/sources.list.d/postgresql.list

--- a/rails/Dockerfile.rails
+++ b/rails/Dockerfile.rails
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-MAINTAINER tech@flow.io
+LABEL maintainer="tech@flow.io"
 
 # refresh list of packages
 RUN apt-get update


### PR DESCRIPTION
I had noticed that the node Docker file had been updated to the suggested engine feature although not play, postgresql or rails.

[Deprecated Engine Features (v.13.0)](https://docs.docker.com/engine/deprecated/#maintainer-in-dockerfile)