### PR TITLE
FDN-1976: Install aws-cli from Alpine rather than pip

### DIFF
--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -16,8 +16,7 @@ WORKDIR /root
 
 RUN apk update && apk upgrade && \
     npm install -g forever && \
-    apk add --no-cache --update python3 py-pip ca-certificates musl-dev git go make build-base curl && \
-    pip install --upgrade awscli
+    apk add --no-cache --update aws-cli python3 py-pip ca-certificates musl-dev git go make build-base curl
 
 RUN git clone "https://$GITHUB_TOKEN@github.com/flowcommerce/tools" && \
     cd tools && \


### PR DESCRIPTION
Installing the AWS cli via pip [no longer works][build] as pip refuses to install packages globally because that would clobber the distribution-managed Python packages.

It's possible to install via pip using a virtualenv but then one has to activate it prior to use, so we probably would have to wrap invocations of the aws command to activate the virtual env first. I'd prefer to install via apk instead. The version instealled by apk is 2.13.25-r0 while the version installed via pip is 1.32.11 and there are [breaking changes][changes] so there's some risk.

[build]: https://jenkins.flo.pub/blue/organizations/jenkins/flowcommerce%2Fdocker/detail/main/34/pipeline/
[changes]: https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration-changes.html#cliv2-migration-changes-breaking