### PR TITLE
FDN-2325: Curl addition for scoverage comment

### DIFF
--- a/Dockerfile-play-builder-17
+++ b/Dockerfile-play-builder-17
@@ -35,11 +35,10 @@ WORKDIR /root
 # Install SBT
 RUN apk update && apk upgrade && \
     apk add --no-cache --update bash postgresql-client && \
-    apk add --no-cache curl && \
+    apk add --no-cache --virtual=build-dependencies curl && \
     curl -sL "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | gunzip | tar -x -C /usr/local && \
     ln -s /usr/local/sbt/bin/sbt /usr/local/bin/sbt && \
     chmod 0755 /usr/local/bin/sbt && \
-    apk del build-dependencies && \
     mkdir -p .sbt/ && \
     mkdir -p .ivy2/
 

--- a/Dockerfile-play-builder-17
+++ b/Dockerfile-play-builder-17
@@ -35,7 +35,7 @@ WORKDIR /root
 # Install SBT
 RUN apk update && apk upgrade && \
     apk add --no-cache --update bash postgresql-client && \
-    apk add --no-cache --virtual=build-dependencies curl && \
+    apk add --no-cache curl && \
     curl -sL "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | gunzip | tar -x -C /usr/local && \
     ln -s /usr/local/sbt/bin/sbt /usr/local/bin/sbt && \
     chmod 0755 /usr/local/bin/sbt && \


### PR DESCRIPTION
Corrected installation of curl in docker image as we have to use curl command in pipeline for scoverage report. So to put report url in pr comment.

Final Stage: For the second stage a fresh eclipse-temurin:17-jdk-alpine image is used. Curl is temporarily installed here as a build dependency using --virtual=build-dependencies flag(Ref: https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#virtual-packages). It is a technique often employed for installing packages that are only necessary during the build process. Once sbt is installed, apk del build-dependencies command removes not only curl but also any other package under build-dependencies virtual package. Also COPY --from=builder commands bring artifacts over from builder stage such as .sbt and .cache directories where compiled binaries along with cached dependencies reside instead of curl https://github.com/flowcommerce/docker/blob/0108a1053d00c896bbde3bed8f02981e7810de48/Dockerfile-play-builder-17#L14.
