### PR TITLE
FDN-2639: Revert play image back to Ubuntu 22.04

### DIFF
--- a/Dockerfile-play-17
+++ b/Dockerfile-play-17
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:17-jre-jammy
 
 LABEL maintainer="tech@flow.io"
 


### PR DESCRIPTION
Recently the eclipse-temurin:17-jre image switched from Ubuntu 22.04 to 24.04, which caused a number of docker build errors (specifically in label and ml-item-classification). Changing the base image to lock-in Ubuntu 22.04 (Jammy)