### PR TITLE
FDN-3609: do not build the "tools" repository in builder images

### DIFF
--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -18,12 +18,6 @@ RUN apk update && apk upgrade && \
     npm install -g forever && \
     apk add --no-cache --update aws-cli python3 py-pip ca-certificates musl-dev git go make build-base curl
 
-RUN git clone "https://$GITHUB_TOKEN@github.com/flowcommerce/tools" && \
-    cd tools && \
-    make install && \
-    cd .. && \
-    rm -rf tools # to remove the token
-
 RUN mkdir -p /opt/node/log
 COPY .npmrc /opt/node/.npmrc
 

--- a/Dockerfile-play-builder-17-jammy
+++ b/Dockerfile-play-builder-17-jammy
@@ -50,9 +50,6 @@ RUN curl -sL "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SB
 RUN ln -s /usr/local/sbt/bin/sbt /usr/local/bin/sbt
 RUN chmod 0755 /usr/local/bin/sbt
 RUN curl -L -o /amm https://github.com/lihaoyi/Ammonite/releases/download/$AMMONITE_VERSION/${SCALA_VERSION}-$AMMONITE_VERSION
-RUN git clone "https://$GITHUB_TOKEN@github.com/flowcommerce/tools.git" && \
-    cd tools && \
-    make install
 RUN for repo in $PROJECTS_TO_BUILD; do echo $repo; git clone --depth 1 https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/flowcommerce/$repo.git; cd $repo; sbt update; cd -; done
 
 


### PR DESCRIPTION
This will allow to upgrade the Go compiler and dependencies in the tools repository.
Otherwise we're stuck with Go 1.18 from the base image (Ubuntu jammy).

### Testing

I figured if the `dev` binary is used in some builder image, it would be in some Jenkinsfile.
So I did a search for that, with turned up empty:

	csearch -f Jenkinsfile 'dev '

The search string contains a space to avoid noise.
It's plausible, as usages of `dev` would be followed by a subcommand, i.e., `dev env`.
